### PR TITLE
Titel für Gesellschaftswissenschaften hinzugefügt

### DIFF
--- a/gewi.xml
+++ b/gewi.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="http://bsbb.eu fachtype.xsd">
 
 	<id>C-GEWIWI</id>
-	<title></title>
+	<title>Gesellschaftswissenschaften</title>
 	<c1>
 		<id>C-GEWI-1</id>
 		<title>Kompetenzentwicklung im Fach Gesellschaftswissenschaften 5/6</title>


### PR DESCRIPTION
Hi Henry. Im Fach Gesellschaftswissenschaften fehlte der Titel ... ich hab ihn mal hinzugefügt. Grüße, Christian